### PR TITLE
fix: tenant error handling, update uniqueness check, and search param

### DIFF
--- a/parkhub-api/internal/handler/tenant_handler.go
+++ b/parkhub-api/internal/handler/tenant_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -170,20 +171,42 @@ func (h *TenantHandler) handleError(c *gin.Context, err error) {
 		return
 	}
 
-	if err == domain.ErrTenantNotFound {
-		c.JSON(http.StatusNotFound, dto.ErrorResponse{
-			Code:    "TENANT_NOT_FOUND",
-			Message: "租户不存在",
+	// Structured domain errors (DomainError with code + message)
+	var domainErr *domain.DomainError
+	if errors.As(err, &domainErr) {
+		status := tenantDomainErrToHTTPStatus(domainErr.Code)
+		c.JSON(status, dto.ErrorResponse{
+			Code:    domainErr.Code,
+			Message: domainErr.Message,
 		})
 		return
 	}
 
-	status := http.StatusInternalServerError
-	code := "INTERNAL_ERROR"
-	message := "服务器内部错误"
+	// Sentinel errors
+	switch {
+	case errors.Is(err, domain.ErrTenantNotFound):
+		c.JSON(http.StatusNotFound, dto.ErrorResponse{
+			Code:    "TENANT_NOT_FOUND",
+			Message: "租户不存在",
+		})
+	default:
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "服务器内部错误",
+		})
+	}
+}
 
-	c.JSON(status, dto.ErrorResponse{
-		Code:    code,
-		Message: message,
-	})
+// tenantDomainErrToHTTPStatus maps tenant-related DomainError codes to HTTP status codes.
+func tenantDomainErrToHTTPStatus(code string) int {
+	switch code {
+	case "COMPANY_NAME_EXISTS", "TENANT_ALREADY_FROZEN", "TENANT_ALREADY_ACTIVE":
+		return http.StatusConflict
+	case domain.CodeNotFound:
+		return http.StatusNotFound
+	case domain.CodePermissionDenied:
+		return http.StatusForbidden
+	default:
+		return http.StatusBadRequest
+	}
 }

--- a/parkhub-api/internal/repository/impl/tenant_repo.go
+++ b/parkhub-api/internal/repository/impl/tenant_repo.go
@@ -91,3 +91,11 @@ func (r *tenantRepo) ExistsByCompanyName(ctx context.Context, companyName string
 	err := r.db.WithContext(ctx).Model(&dao.TenantDAO{}).Where("company_name = ?", companyName).Count(&count).Error
 	return count > 0, err
 }
+
+func (r *tenantRepo) ExistsByCompanyNameExcluding(ctx context.Context, companyName string, excludeID string) (bool, error) {
+	var count int64
+	err := r.db.WithContext(ctx).Model(&dao.TenantDAO{}).
+		Where("company_name = ? AND id != ?", companyName, excludeID).
+		Count(&count).Error
+	return count > 0, err
+}

--- a/parkhub-api/internal/repository/interface.go
+++ b/parkhub-api/internal/repository/interface.go
@@ -13,6 +13,7 @@ type TenantRepo interface {
 	FindByID(ctx context.Context, id string) (*domain.Tenant, error)
 	FindAll(ctx context.Context, filter TenantFilter) ([]*domain.Tenant, int64, error)
 	ExistsByCompanyName(ctx context.Context, companyName string) (bool, error)
+	ExistsByCompanyNameExcluding(ctx context.Context, companyName string, excludeID string) (bool, error)
 }
 
 // TenantFilter 租户查询过滤器

--- a/parkhub-api/internal/service/impl/auth_service_test.go
+++ b/parkhub-api/internal/service/impl/auth_service_test.go
@@ -138,6 +138,15 @@ func (m *mockTenantRepo) ExistsByCompanyName(ctx context.Context, companyName st
 	return false, nil
 }
 
+func (m *mockTenantRepo) ExistsByCompanyNameExcluding(ctx context.Context, companyName string, excludeID string) (bool, error) {
+	for _, tenant := range m.tenants {
+		if tenant.CompanyName == companyName && tenant.ID != excludeID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 type mockRefreshTokenRepo struct {
 	tokens map[string]*domain.RefreshToken
 }

--- a/parkhub-api/internal/service/impl/tenant_service.go
+++ b/parkhub-api/internal/service/impl/tenant_service.go
@@ -83,6 +83,20 @@ func (s *tenantServiceImpl) Update(ctx context.Context, id string, req *service.
 		return nil, err
 	}
 
+	// Check for duplicate company name if it changed
+	if req.CompanyName != tenant.CompanyName {
+		exists, err := s.tenantRepo.ExistsByCompanyNameExcluding(ctx, req.CompanyName, id)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			return nil, &domain.DomainError{
+				Code:    "COMPANY_NAME_EXISTS",
+				Message: "公司名称已存在",
+			}
+		}
+	}
+
 	tenant.UpdateCompanyName(req.CompanyName)
 	tenant.UpdateContact(req.ContactName, req.ContactPhone)
 

--- a/parkhub-web/lib/tenant/api.ts
+++ b/parkhub-web/lib/tenant/api.ts
@@ -51,7 +51,7 @@ function buildQueryString(filter: TenantFilter): string {
     params.append('status', filter.status);
   }
   if (filter.search) {
-    params.append('search', filter.search);
+    params.append('keyword', filter.search);
   }
   if (filter.page) {
     params.append('page', filter.page.toString());


### PR DESCRIPTION
## Summary
- **Tenant handler error mapping**: `handleError` now extracts `*domain.DomainError` and maps codes to proper HTTP statuses (409 Conflict for `COMPANY_NAME_EXISTS`/`TENANT_ALREADY_FROZEN`/`TENANT_ALREADY_ACTIVE`, 400 for other business errors) instead of returning blanket 500 Internal Server Error
- **Duplicate name check on update**: Added `ExistsByCompanyNameExcluding` to repo interface/impl, and the tenant service `Update` now validates company name uniqueness (excluding the current tenant) before persisting — matching the existing `Create` behavior
- **Frontend search query key**: Fixed `buildQueryString` in `parkhub-web/lib/tenant/api.ts` to send `keyword` instead of `search`, matching the backend handler's `c.Query("keyword")`

## Test plan
- [x] Create two tenants, try renaming one to the other's company name → expect 409 with `COMPANY_NAME_EXISTS`
- [x] Freeze an already-frozen tenant → expect 409 with `TENANT_ALREADY_FROZEN` (not 500)
- [x] Unfreeze an active tenant → expect 409 with `TENANT_ALREADY_ACTIVE` (not 500)
- [x] Type a search term in tenant management UI → verify backend returns filtered results