### PR TITLE
fix: resolve two failing auth service tests

### DIFF
--- a/parkhub-api/internal/pkg/jwt/jwt.go
+++ b/parkhub-api/internal/pkg/jwt/jwt.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -15,7 +16,7 @@ const (
 
 // 默认有效期
 const (
-	DefaultAccessTokenTTL  = 2 * time.Hour    // Access Token 2小时
+	DefaultAccessTokenTTL  = 2 * time.Hour      // Access Token 2小时
 	DefaultRefreshTokenTTL = 7 * 24 * time.Hour // Refresh Token 7天
 )
 
@@ -78,6 +79,7 @@ func (m *JWTManager) generateToken(userID string, tenantID *string, role, tokenT
 		Role:     role,
 		Type:     tokenType,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        fmt.Sprintf("%d", now.UnixNano()),
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 			Issuer:    m.issuer,

--- a/parkhub-api/internal/service/impl/auth_service_test.go
+++ b/parkhub-api/internal/service/impl/auth_service_test.go
@@ -448,11 +448,23 @@ func TestGetCurrentUser_Success(t *testing.T) {
 }
 
 func TestTenantIsolation(t *testing.T) {
-	authService, userRepo, _ := setupTestAuthService()
+	authService, userRepo, tenantRepo := setupTestAuthService()
+
+	// 创建另一个租户
+	otherTenantID := "tenant-2"
+	otherTenant := &domain.Tenant{
+		ID:           otherTenantID,
+		CompanyName:  "其他公司",
+		ContactName:  "其他联系人",
+		ContactPhone: "13900139000",
+		Status:       domain.TenantStatusActive,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	tenantRepo.tenants[otherTenant.ID] = otherTenant
 
 	// 创建另一个租户的用户
 	passwordHash, _ := crypto.HashPassword("Password123")
-	otherTenantID := "tenant-2"
 	otherUser := &domain.User{
 		ID:           "user-2",
 		TenantID:     &otherTenantID,
@@ -487,7 +499,6 @@ func TestTenantIsolation(t *testing.T) {
 		t.Error("Users from different tenants should have different tenant IDs")
 	}
 }
-
 
 func hashToken(token string) string {
 	hash := sha256.Sum256([]byte(token))


### PR DESCRIPTION
## Summary
- 修复 `TestRefreshToken_Success`: 在 JWT token 中添加唯一的 `jti` (JWT ID) 字段，使用纳秒时间戳确保每次生成的 token 都不同
- 修复 `TestTenantIsolation`: 测试中创建用户前需要先创建对应的租户 `tenant-2`

## Test plan
- [x] 运行 `go test ./internal/service/impl/... ./internal/pkg/jwt/...` 所有测试通过