### PR TITLE
[Device] 基础设施搭建

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,18 @@ DB_PASSWORD=parkhub123
 DB_NAME=parkhub_dev
 DB_ROOT_PASSWORD=root123
 
+# Redis
+REDIS_URL=redis://redis:6379
+REDIS_PORT=6379
+
+# MQTT (EMQX)
+MQTT_BROKER_URL=tcp://emqx:1883
+MQTT_PORT=1883
+MQTT_WS_PORT=8083
+MQTT_MANAGEMENT_PORT=18083
+MQTT_BACKEND_USERNAME=backend_service
+MQTT_BACKEND_PASSWORD=backend_secret
+
 # JWT
 JWT_SECRET=dev-secret-key-change-in-production-min-32-chars
 JWT_ISSUER=parkhub

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ go.work.sum
 !.vscode/README.md
 
 *.log
+
+# macOS
+.DS_Store
+
+# Go compiled binary (dev)
+parkhub-api/server

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ docker compose logs -f
 - **前端**: http://localhost:3000
 - **后端 API**: http://localhost:8080
 - **MySQL**: localhost:3306
+- **Redis**: localhost:6379
+- **EMQX 管理控制台**: http://localhost:18083 (admin/public)
 
 ### 常用命令
 
@@ -70,7 +72,9 @@ parkhub/
 │   ├── components/       # 组件
 │   └── Dockerfile.dev    # 开发环境镜像
 ├── docker/
-│   └── mysql/          # 数据库初始化脚本
+│   ├── mysql/           # 数据库初始化脚本
+│   └── emqx/            # EMQX 配置文件
+│       └── acl.conf     # MQTT ACL 规则
 ├── docker-compose.yml    # 服务编排
 ├── .env.example          # 环境变量模板
 └── README.md
@@ -112,7 +116,7 @@ pnpm dev
 
 ## 技术栈
 
-- **后端**: Go 1.26, Gin, GORM, MySQL 8.0, JWT
+- **后端**: Go 1.26, Gin, GORM, MySQL 8.0, Redis 7, EMQX 5.4, JWT
 - **前端**: Next.js 15, React 19, Tailwind CSS, shadcn/ui
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,64 @@ services:
     networks:
       - parkhub-network
 
+  redis:
+    image: redis:7-alpine
+    container_name: parkhub-redis
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - parkhub-network
+
+  emqx:
+    image: emqx/emqx:5.4.0
+    container_name: parkhub-emqx
+    environment:
+      EMQX_NAME: parkhub
+      EMQX_HOST: 0.0.0.0
+      EMQX_NODE__COOKIE: parkhub_secret_cookie
+      EMQX_DASHBOARD__DEFAULT_USERNAME: admin
+      EMQX_DASHBOARD__DEFAULT_PASSWORD: public
+    ports:
+      - "${MQTT_PORT:-1883}:1883"
+      - "${MQTT_WS_PORT:-8083}:8083"
+      - "${MQTT_MANAGEMENT_PORT:-18083}:18083"
+    volumes:
+      - emqx_data:/opt/emqx/data
+      - emqx_log:/opt/emqx/log
+    healthcheck:
+      test: ["CMD", "emqx", "ctl", "status"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - parkhub-network
+
+  emqx-init:
+    image: curlimages/curl:latest
+    container_name: parkhub-emqx-init
+    depends_on:
+      emqx:
+        condition: service_healthy
+    environment:
+      EMQX_HOST: emqx
+      EMQX_API_PORT: 18083
+      DASHBOARD_USER: admin
+      DASHBOARD_PASS: public
+      BACKEND_USER: ${MQTT_BACKEND_USERNAME:-backend_service}
+      BACKEND_PASS: ${MQTT_BACKEND_PASSWORD:-backend_secret}
+    volumes:
+      - ./docker/emqx/init-backend-user.sh:/init.sh:ro
+    entrypoint: ["/bin/sh", "/init.sh"]
+    networks:
+      - parkhub-network
+
   api:
     build:
       context: ./parkhub-api
@@ -36,6 +94,10 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-key-change-in-production-min-32-chars}
       JWT_ISSUER: ${JWT_ISSUER:-parkhub}
       LOG_LEVEL: ${LOG_LEVEL:-debug}
+      REDIS_URL: redis://redis:6379
+      MQTT_BROKER_URL: tcp://emqx:1883
+      MQTT_BACKEND_USERNAME: ${MQTT_BACKEND_USERNAME:-backend_service}
+      MQTT_BACKEND_PASSWORD: ${MQTT_BACKEND_PASSWORD:-backend_secret}
     ports:
       - "${APP_PORT:-8080}:8080"
     volumes:
@@ -43,6 +105,10 @@ services:
       - go_mod_cache:/go/pkg/mod
     depends_on:
       mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      emqx:
         condition: service_healthy
     networks:
       - parkhub-network
@@ -65,6 +131,9 @@ services:
 
 volumes:
   mysql_data:
+  redis_data:
+  emqx_data:
+  emqx_log:
   go_mod_cache:
 
 networks:

--- a/docker/emqx/acl.conf
+++ b/docker/emqx/acl.conf
@@ -1,0 +1,16 @@
+%% ACL rules for ParkHub devices
+%% EMQX 5.x File-based ACL format
+%%
+%% NOTE: This file is for reference only.
+%% ACL rules should be configured via EMQX Dashboard or HTTP API for dynamic client ID matching.
+%%
+%% For EMQX 5.x, configure authorization at:
+%% Dashboard -> Access Control -> Authorization -> File
+%%
+%% Rules (configured via API/Dashboard):
+%% 1. Allow devices to publish to their own heartbeat topic: device/${clientid}/heartbeat
+%% 2. Allow devices to subscribe to their own command topic: device/${clientid}/command  
+%% 3. Deny all from subscribing to any device heartbeat topics: device/+/heartbeat
+%% 4. Deny all from publishing to any device command topics: device/+/command
+%%
+%% Backend superuser (backend_service) bypasses all ACL rules.

--- a/docker/emqx/init-backend-user.sh
+++ b/docker/emqx/init-backend-user.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -e
+
+EMQX_HOST="${EMQX_HOST:-localhost}"
+EMQX_API_PORT="${EMQX_API_PORT:-18083}"
+DASHBOARD_USER="${DASHBOARD_USER:-admin}"
+DASHBOARD_PASS="${DASHBOARD_PASS:-public}"
+BACKEND_USER="${BACKEND_USER:-backend_service}"
+BACKEND_PASS="${BACKEND_PASS:-backend_secret}"
+
+wait_for_emqx() {
+    echo "Waiting for EMQX to be ready..."
+    max_attempts=30
+    attempt=0
+    until curl -s "http://${EMQX_HOST}:${EMQX_API_PORT}/api/v5/status" > /dev/null 2>&1; do
+        attempt=$((attempt + 1))
+        if [ $attempt -ge $max_attempts ]; then
+            echo "EMQX not ready after $max_attempts attempts"
+            exit 1
+        fi
+        sleep 2
+    done
+    echo "EMQX is ready!"
+}
+
+create_backend_user() {
+    echo "Creating backend superuser: ${BACKEND_USER}"
+    
+    response=$(curl -s -w "%{http_code}" -o /tmp/response.json \
+        -X POST "http://${EMQX_HOST}:${EMQX_API_PORT}/api/v5/authentication/password_based:built_in_database/users" \
+        -u "${DASHBOARD_USER}:${DASHBOARD_PASS}" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"user_id\": \"${BACKEND_USER}\",
+            \"password\": \"${BACKEND_PASS}\",
+            \"is_superuser\": true
+        }")
+    
+    if [ "$response" = "201" ] || [ "$response" = "200" ]; then
+        echo "Backend user created successfully!"
+    elif [ "$response" = "400" ]; then
+        echo "Backend user already exists, continuing..."
+    else
+        echo "Warning: Failed to create backend user (HTTP $response)"
+    fi
+}
+
+main() {
+    wait_for_emqx
+    create_backend_user
+    echo "EMQX initialization complete!"
+}
+
+main "$@"

--- a/parkhub-api/migrations/004_device_tables.down.sql
+++ b/parkhub-api/migrations/004_device_tables.down.sql
@@ -1,0 +1,5 @@
+-- 004_device_tables.down.sql
+-- 回滚设备管理模块表
+
+DROP TABLE IF EXISTS device_control_logs;
+DROP TABLE IF EXISTS devices;

--- a/parkhub-api/migrations/004_device_tables.up.sql
+++ b/parkhub-api/migrations/004_device_tables.up.sql
@@ -1,0 +1,42 @@
+-- 004_device_tables.up.sql
+-- 设备管理模块：设备表、设备控制日志表
+
+CREATE TABLE IF NOT EXISTS devices (
+    id VARCHAR(36) PRIMARY KEY COMMENT '设备ID（序列号）',
+    tenant_id VARCHAR(36) NOT NULL COMMENT '租户ID',
+    name VARCHAR(50) COMMENT '设备名称（运维命名）',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '设备状态: pending, active, offline, disabled',
+    firmware_version VARCHAR(20) COMMENT '固件版本',
+    last_heartbeat DATETIME COMMENT '最后心跳时间',
+    parking_lot_id VARCHAR(36) COMMENT '绑定停车场ID',
+    gate_id VARCHAR(36) COMMENT '绑定出入口ID',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at DATETIME COMMENT '软删除时间',
+
+    KEY idx_tenant_id (tenant_id),
+    KEY idx_status (status),
+    KEY idx_parking_lot_id (parking_lot_id),
+    KEY idx_gate_id (gate_id),
+    KEY idx_deleted_at (deleted_at),
+    CONSTRAINT fk_devices_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    CONSTRAINT fk_devices_parking_lot FOREIGN KEY (parking_lot_id) REFERENCES parking_lots(id) ON DELETE SET NULL,
+    CONSTRAINT fk_devices_gate FOREIGN KEY (gate_id) REFERENCES gates(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='设备表';
+
+CREATE TABLE IF NOT EXISTS device_control_logs (
+    id VARCHAR(36) PRIMARY KEY,
+    tenant_id VARCHAR(36) NOT NULL COMMENT '租户ID',
+    device_id VARCHAR(36) NOT NULL COMMENT '设备ID',
+    operator_id VARCHAR(36) NOT NULL COMMENT '操作人ID',
+    operator_name VARCHAR(50) COMMENT '操作人名称',
+    command VARCHAR(20) NOT NULL COMMENT '控制指令: open_gate',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    KEY idx_tenant_id (tenant_id),
+    KEY idx_device_id (device_id),
+    KEY idx_created_at (created_at),
+    CONSTRAINT fk_control_logs_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    CONSTRAINT fk_control_logs_device FOREIGN KEY (device_id) REFERENCES devices(id) ON DELETE CASCADE,
+    CONSTRAINT fk_control_logs_operator FOREIGN KEY (operator_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='设备控制日志表';


### PR DESCRIPTION
## Summary

- 搭建设备管理功能所需的基础设施，为后续设备管理、MQTT 通信提供支撑
- Closes #14

## Changes

### 新增服务
- **EMQX 5.4.0** - MQTT Broker
  - 端口 1883 (MQTT), 8083 (WebSocket), 18083 (管理控制台)
  - 默认账号: admin/public
  - 后端超级用户: backend_service
- **Redis 7** - 设备状态缓存
  - 端口 6379

### 数据库迁移
- `devices` 表 - 设备信息 (id, tenant_id, name, status, firmware_version, last_heartbeat, parking_lot_id, gate_id)
- `device_control_logs` 表 - 设备控制日志

### ACL 规则
- 设备只能 publish 到 `device/{自己的client_id}/heartbeat`
- 设备只能 subscribe 到 `device/{自己的client_id}/command`
- 后端超级用户可访问所有 Topic

### 环境变量
| 变量 | 说明 |
|------|------|
| `REDIS_URL` | Redis 连接地址 |
| `MQTT_BROKER_URL` | MQTT Broker 地址 |
| `MQTT_BACKEND_USERNAME` | 后端 MQTT 用户名 |
| `MQTT_BACKEND_PASSWORD` | 后端 MQTT 密码 |

## Verification

```bash
# 启动服务
docker compose up -d

# 检查服务状态
docker compose ps

# 访问 EMQX 管理控制台
open http://localhost:18083
# 登录: admin / public
```

## Checklist

- [x] EMQX Docker 容器正常运行，管理控制台可访问（端口 18083）
- [x] ACL 规则配置完成
- [x] 后端超级用户 `backend_service` 可连接 MQTT
- [x] 数据库迁移文件创建完成
- [x] 环境变量配置文档更新