### PR TITLE
fix(api): 补齐设备远程控制 MQTT 发布链路

### DIFF
--- a/parkhub-api/cmd/server/main.go
+++ b/parkhub-api/cmd/server/main.go
@@ -89,6 +89,7 @@ func main() {
 
 	// Start heartbeat service with the connected MQTT client
 	heartbeatSvc.SetMQTTClient(mqttClient)
+	r.SetDeviceControlMQTTClient(mqttClient)
 	heartbeatSvc.Start()
 
 	srv := &http.Server{

--- a/parkhub-api/internal/handler/device_handler.go
+++ b/parkhub-api/internal/handler/device_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gin-gonic/gin"
 	"github.com/google/wire"
 	"github.com/parkhub/api/internal/domain"
@@ -23,6 +24,14 @@ func NewDeviceHandler(deviceService service.DeviceService, deviceControlService 
 	return &DeviceHandler{
 		deviceService:        deviceService,
 		deviceControlService: deviceControlService,
+	}
+}
+
+func (h *DeviceHandler) SetMQTTClient(client pahomqtt.Client) {
+	if svc, ok := h.deviceControlService.(interface {
+		SetMQTTClient(pahomqtt.Client)
+	}); ok {
+		svc.SetMQTTClient(client)
 	}
 }
 

--- a/parkhub-api/internal/router/router.go
+++ b/parkhub-api/internal/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	pahomqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gin-gonic/gin"
 	"github.com/google/wire"
 	"github.com/parkhub/api/internal/handler"
@@ -49,6 +50,10 @@ func NewRouter(
 // GetEngine returns the underlying gin.Engine.
 func (r *Router) GetEngine() *gin.Engine {
 	return r.engine
+}
+
+func (r *Router) SetDeviceControlMQTTClient(client pahomqtt.Client) {
+	r.deviceHandler.SetMQTTClient(client)
 }
 
 // Setup 设置所有路由


### PR DESCRIPTION
## 背景
Issue #18 要求设备远程控制时将指令发布到 MQTT 主题 `device/{device_id}/command`。

现状中控制服务实现了发布逻辑，但运行时未注入 MQTT client，导致仅记录日志而不会真正发布指令。

## 变更
- 在 `Router` 增加 `SetDeviceControlMQTTClient` 注入入口
- 在 `DeviceHandler` 增加 `SetMQTTClient`，向控制服务透传 MQTT client
- 在 `cmd/server/main.go` 连接 MQTT 后，调用 `r.SetDeviceControlMQTTClient(mqttClient)`

## 验收对应
- `POST /api/v1/devices/:id/control` 触发控制时，指令可真正发布到 MQTT 主题
- 指令格式仍为 `{command, operator_id, operator_name, timestamp}`
- 不影响既有离线校验、权限和控制日志落库逻辑

## 测试
- `cd parkhub-api && go test ./...`
- `cd parkhub-api && go build ./cmd/server`

Closes #18
