### PR TITLE
feat(device): 实现设备状态管理（禁用/启用/删除）

### DIFF
--- a/parkhub-api/internal/domain/device.go
+++ b/parkhub-api/internal/domain/device.go
@@ -33,6 +33,7 @@ var (
 	ErrDeviceNotFound    = errors.New("设备不存在")
 	ErrDeviceIDDuplicate = errors.New("设备序列号已存在")
 	ErrDeviceNotBound    = errors.New("设备当前未绑定")
+	ErrDeviceMustUnbind  = errors.New("设备已绑定，请先解绑后删除")
 	ErrDeviceOffline     = errors.New("设备离线请检查心跳")
 	ErrInvalidCommand    = errors.New("无效的控制指令")
 )

--- a/parkhub-api/internal/handler/device_handler.go
+++ b/parkhub-api/internal/handler/device_handler.go
@@ -210,6 +210,64 @@ func (h *DeviceHandler) Unbind(c *gin.Context) {
 	})
 }
 
+func (h *DeviceHandler) Disable(c *gin.Context) {
+	id := c.Param("id")
+	tenantID := c.GetString("tenant_id")
+
+	device, err := h.deviceService.Disable(c.Request.Context(), &service.ChangeDeviceStatusRequest{
+		ID:       id,
+		TenantID: tenantID,
+	})
+	if err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.Response{
+		Code:    0,
+		Message: "设备已禁用",
+		Data:    h.toDeviceDetailDTO(device),
+	})
+}
+
+func (h *DeviceHandler) Enable(c *gin.Context) {
+	id := c.Param("id")
+	tenantID := c.GetString("tenant_id")
+
+	device, err := h.deviceService.Enable(c.Request.Context(), &service.ChangeDeviceStatusRequest{
+		ID:       id,
+		TenantID: tenantID,
+	})
+	if err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.Response{
+		Code:    0,
+		Message: "设备已启用",
+		Data:    h.toDeviceDetailDTO(device),
+	})
+}
+
+func (h *DeviceHandler) Delete(c *gin.Context) {
+	id := c.Param("id")
+	tenantID := c.GetString("tenant_id")
+
+	if err := h.deviceService.Delete(c.Request.Context(), &service.DeleteDeviceRequest{
+		ID:       id,
+		TenantID: tenantID,
+	}); err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.Response{
+		Code:    0,
+		Message: "设备已删除",
+	})
+}
+
 // GetStats 获取设备统计
 func (h *DeviceHandler) GetStats(c *gin.Context) {
 	tenantID := c.GetString("tenant_id")
@@ -294,7 +352,7 @@ func (h *DeviceHandler) handleError(c *gin.Context, err error) {
 			c.JSON(http.StatusConflict, dto.Response{Code: 40901, Message: de.Message})
 		case "FORBIDDEN":
 			c.JSON(http.StatusForbidden, dto.Response{Code: 40301, Message: de.Message})
-		case "DEVICE_INVALID_STATUS", "DEVICE_GATE_CAPACITY_EXCEEDED", "DEVICE_NOT_BOUND":
+		case "DEVICE_INVALID_STATUS", "DEVICE_GATE_CAPACITY_EXCEEDED", "DEVICE_NOT_BOUND", "DEVICE_MUST_UNBIND":
 			c.JSON(http.StatusBadRequest, dto.Response{Code: 40003, Message: de.Message})
 		case "TENANT_NOT_FOUND", "PARKING_LOT_NOT_FOUND", "GATE_NOT_FOUND":
 			c.JSON(http.StatusNotFound, dto.Response{Code: 40402, Message: de.Message})

--- a/parkhub-api/internal/handler/device_handler_test.go
+++ b/parkhub-api/internal/handler/device_handler_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 type stubDeviceService struct {
-	bindFn   func(ctx context.Context, req *service.BindDeviceRequest) (*domain.Device, error)
-	unbindFn func(ctx context.Context, req *service.UnbindDeviceRequest) (*domain.Device, error)
+	bindFn    func(ctx context.Context, req *service.BindDeviceRequest) (*domain.Device, error)
+	unbindFn  func(ctx context.Context, req *service.UnbindDeviceRequest) (*domain.Device, error)
+	disableFn func(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error)
+	enableFn  func(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error)
+	deleteFn  func(ctx context.Context, req *service.DeleteDeviceRequest) error
 }
 
 func (s *stubDeviceService) Create(ctx context.Context, req *service.CreateDeviceRequest) (*domain.Device, error) {
@@ -44,6 +47,27 @@ func (s *stubDeviceService) Unbind(ctx context.Context, req *service.UnbindDevic
 
 func (s *stubDeviceService) GetStats(ctx context.Context, tenantID string) (*service.DeviceStatsResponse, error) {
 	return nil, nil
+}
+
+func (s *stubDeviceService) Disable(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error) {
+	if s.disableFn == nil {
+		return nil, nil
+	}
+	return s.disableFn(ctx, req)
+}
+
+func (s *stubDeviceService) Enable(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error) {
+	if s.enableFn == nil {
+		return nil, nil
+	}
+	return s.enableFn(ctx, req)
+}
+
+func (s *stubDeviceService) Delete(ctx context.Context, req *service.DeleteDeviceRequest) error {
+	if s.deleteFn == nil {
+		return nil
+	}
+	return s.deleteFn(ctx, req)
 }
 
 // stubDeviceControlService is a stub implementation for the tests
@@ -114,6 +138,35 @@ func TestDeviceHandler_Unbind_MapsDomainError(t *testing.T) {
 	router.POST("/devices/:id/unbind", handler.Unbind)
 
 	req := httptest.NewRequest(http.MethodPost, "/devices/device-1/unbind", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("status = %v, want 400", resp.Code)
+	}
+	if !bytes.Contains(resp.Body.Bytes(), []byte(`"code":40003`)) {
+		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestDeviceHandler_Delete_MapsDomainError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	svc := &stubDeviceService{
+		deleteFn: func(ctx context.Context, req *service.DeleteDeviceRequest) error {
+			return &domain.DomainError{Code: "DEVICE_MUST_UNBIND", Message: "设备已绑定，请先解绑后删除"}
+		},
+	}
+	controlSvc := &stubDeviceControlService{}
+	handler := NewDeviceHandler(svc, controlSvc)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "tenant-1")
+	})
+	router.DELETE("/devices/:id", handler.Delete)
+
+	req := httptest.NewRequest(http.MethodDelete, "/devices/device-1", nil)
 	resp := httptest.NewRecorder()
 	router.ServeHTTP(resp, req)
 

--- a/parkhub-api/internal/repository/impl/device_repo.go
+++ b/parkhub-api/internal/repository/impl/device_repo.go
@@ -196,6 +196,24 @@ func (r *deviceRepo) Update(ctx context.Context, device *domain.Device) error {
 	return nil
 }
 
+func (r *deviceRepo) Delete(ctx context.Context, id string) error {
+	now := r.db.NowFunc()
+	result := r.db.WithContext(ctx).
+		Model(&dao.DeviceDAO{}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		Updates(map[string]any{
+			"deleted_at": now,
+			"updated_at": now,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return domain.ErrDeviceNotFound
+	}
+	return nil
+}
+
 func (r *deviceRepo) UpdateHeartbeat(ctx context.Context, device *domain.Device) error {
 	d := dao.ToDeviceDAO(device)
 	return r.db.WithContext(ctx).Model(d).Where("deleted_at IS NULL").Updates(map[string]any{

--- a/parkhub-api/internal/repository/interface.go
+++ b/parkhub-api/internal/repository/interface.go
@@ -138,6 +138,7 @@ type DeviceRepo interface {
 	CountByGateID(ctx context.Context, gateID string) (int64, error)
 	FindByGateID(ctx context.Context, gateID string) ([]*domain.Device, error)
 	Update(ctx context.Context, device *domain.Device) error
+	Delete(ctx context.Context, id string) error
 	UpdateHeartbeat(ctx context.Context, device *domain.Device) error
 	UnbindByGateID(ctx context.Context, gateID string) error
 	FindTimedOutDevices(ctx context.Context, threshold time.Time) ([]*domain.Device, error)

--- a/parkhub-api/internal/router/router.go
+++ b/parkhub-api/internal/router/router.go
@@ -232,5 +232,14 @@ func (r *Router) setupDeviceRoutes(rg *gin.RouterGroup) {
 
 		// POST /api/v1/devices/:id/control - 远程控制设备
 		devices.POST("/:id/control", r.deviceHandler.Control)
+
+		// POST /api/v1/devices/:id/disable - 禁用设备（仅admin）
+		devices.POST("/:id/disable", middleware.RequireRoles("platform_admin", "tenant_admin"), r.deviceHandler.Disable)
+
+		// POST /api/v1/devices/:id/enable - 启用设备（仅admin）
+		devices.POST("/:id/enable", middleware.RequireRoles("platform_admin", "tenant_admin"), r.deviceHandler.Enable)
+
+		// DELETE /api/v1/devices/:id - 删除设备（仅admin）
+		devices.DELETE("/:id", middleware.RequireRoles("platform_admin", "tenant_admin"), r.deviceHandler.Delete)
 	}
 }

--- a/parkhub-api/internal/service/impl/device_control_service_test.go
+++ b/parkhub-api/internal/service/impl/device_control_service_test.go
@@ -51,6 +51,11 @@ func (m *mockDeviceRepoForControl) Update(ctx context.Context, device *domain.De
 	return nil
 }
 
+func (m *mockDeviceRepoForControl) Delete(ctx context.Context, id string) error {
+	delete(m.devices, id)
+	return nil
+}
+
 func (m *mockDeviceRepoForControl) UpdateHeartbeat(ctx context.Context, device *domain.Device) error {
 	m.devices[device.ID] = device
 	return nil

--- a/parkhub-api/internal/service/impl/device_service.go
+++ b/parkhub-api/internal/service/impl/device_service.go
@@ -285,6 +285,79 @@ func (s *deviceServiceImpl) Unbind(ctx context.Context, req *service.UnbindDevic
 	return device, nil
 }
 
+func (s *deviceServiceImpl) Disable(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error) {
+	device, err := s.deviceRepo.FindByID(ctx, req.ID)
+	if err != nil {
+		if err == domain.ErrDeviceNotFound {
+			return nil, &domain.DomainError{Code: "DEVICE_NOT_FOUND", Message: err.Error()}
+		}
+		return nil, err
+	}
+	if req.TenantID != "" && device.TenantID != req.TenantID {
+		return nil, &domain.DomainError{Code: "FORBIDDEN", Message: "无权操作该设备"}
+	}
+
+	device.Status = domain.DeviceStatusDisabled
+	device.UpdatedAt = time.Now()
+	if err := s.deviceRepo.Update(ctx, device); err != nil {
+		return nil, err
+	}
+
+	return device, nil
+}
+
+func (s *deviceServiceImpl) Enable(ctx context.Context, req *service.ChangeDeviceStatusRequest) (*domain.Device, error) {
+	device, err := s.deviceRepo.FindByID(ctx, req.ID)
+	if err != nil {
+		if err == domain.ErrDeviceNotFound {
+			return nil, &domain.DomainError{Code: "DEVICE_NOT_FOUND", Message: err.Error()}
+		}
+		return nil, err
+	}
+	if req.TenantID != "" && device.TenantID != req.TenantID {
+		return nil, &domain.DomainError{Code: "FORBIDDEN", Message: "无权操作该设备"}
+	}
+	if device.Status != domain.DeviceStatusDisabled {
+		return nil, &domain.DomainError{Code: "DEVICE_INVALID_STATUS", Message: "仅禁用状态设备可启用"}
+	}
+
+	if device.LastHeartbeat != nil && time.Since(*device.LastHeartbeat) < time.Duration(domain.DefaultHeartbeatTimeoutSeconds)*time.Second {
+		device.Status = domain.DeviceStatusActive
+	} else {
+		device.Status = domain.DeviceStatusOffline
+	}
+	device.UpdatedAt = time.Now()
+	if err := s.deviceRepo.Update(ctx, device); err != nil {
+		return nil, err
+	}
+
+	return device, nil
+}
+
+func (s *deviceServiceImpl) Delete(ctx context.Context, req *service.DeleteDeviceRequest) error {
+	device, err := s.deviceRepo.FindByID(ctx, req.ID)
+	if err != nil {
+		if err == domain.ErrDeviceNotFound {
+			return &domain.DomainError{Code: "DEVICE_NOT_FOUND", Message: err.Error()}
+		}
+		return err
+	}
+	if req.TenantID != "" && device.TenantID != req.TenantID {
+		return &domain.DomainError{Code: "FORBIDDEN", Message: "无权操作该设备"}
+	}
+	if device.ParkingLotID != nil || device.GateID != nil {
+		return &domain.DomainError{Code: "DEVICE_MUST_UNBIND", Message: domain.ErrDeviceMustUnbind.Error()}
+	}
+
+	if err := s.deviceRepo.Delete(ctx, req.ID); err != nil {
+		if err == domain.ErrDeviceNotFound {
+			return &domain.DomainError{Code: "DEVICE_NOT_FOUND", Message: err.Error()}
+		}
+		return err
+	}
+	return nil
+}
+
 func (s *deviceServiceImpl) GetStats(ctx context.Context, tenantID string) (*service.DeviceStatsResponse, error) {
 	stats, err := s.deviceRepo.CountByStatus(ctx, tenantID)
 	if err != nil {

--- a/parkhub-api/internal/service/impl/device_service_test.go
+++ b/parkhub-api/internal/service/impl/device_service_test.go
@@ -102,6 +102,14 @@ func (m *mockDeviceRepo) Update(ctx context.Context, device *domain.Device) erro
 	return nil
 }
 
+func (m *mockDeviceRepo) Delete(ctx context.Context, id string) error {
+	if _, ok := m.devices[id]; !ok {
+		return domain.ErrDeviceNotFound
+	}
+	delete(m.devices, id)
+	return nil
+}
+
 func (m *mockDeviceRepo) UpdateHeartbeat(ctx context.Context, device *domain.Device) error {
 	return m.Update(ctx, device)
 }
@@ -416,5 +424,94 @@ func TestDeviceService_Unbind_WritesAuditLog(t *testing.T) {
 	}
 	if detail["parking_lot_id"] != "lot-1" || detail["gate_id"] != "gate-1" || detail["tenant_id"] != "tenant-1" {
 		t.Fatalf("detail = %v", detail)
+	}
+}
+
+func TestDeviceService_Disable_Success(t *testing.T) {
+	svc, deviceRepo, _, _, _ := setupTestDeviceService()
+	createTestDevice(deviceRepo, "device-1", "tenant-1", domain.DeviceStatusActive)
+
+	device, err := svc.Disable(context.Background(), &service.ChangeDeviceStatusRequest{
+		ID:       "device-1",
+		TenantID: "tenant-1",
+	})
+	if err != nil {
+		t.Fatalf("Disable() error = %v", err)
+	}
+	if device.Status != domain.DeviceStatusDisabled {
+		t.Fatalf("Status = %v, want disabled", device.Status)
+	}
+}
+
+func TestDeviceService_Enable_FromDisabled_HeartbeatFreshToActive(t *testing.T) {
+	svc, deviceRepo, _, _, _ := setupTestDeviceService()
+	device := createTestDevice(deviceRepo, "device-1", "tenant-1", domain.DeviceStatusDisabled)
+	now := time.Now().Add(-1 * time.Minute)
+	device.LastHeartbeat = &now
+
+	updated, err := svc.Enable(context.Background(), &service.ChangeDeviceStatusRequest{
+		ID:       "device-1",
+		TenantID: "tenant-1",
+	})
+	if err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+	if updated.Status != domain.DeviceStatusActive {
+		t.Fatalf("Status = %v, want active", updated.Status)
+	}
+}
+
+func TestDeviceService_Enable_FromDisabled_HeartbeatExpiredToOffline(t *testing.T) {
+	svc, deviceRepo, _, _, _ := setupTestDeviceService()
+	device := createTestDevice(deviceRepo, "device-1", "tenant-1", domain.DeviceStatusDisabled)
+	stale := time.Now().Add(-10 * time.Minute)
+	device.LastHeartbeat = &stale
+
+	updated, err := svc.Enable(context.Background(), &service.ChangeDeviceStatusRequest{
+		ID:       "device-1",
+		TenantID: "tenant-1",
+	})
+	if err != nil {
+		t.Fatalf("Enable() error = %v", err)
+	}
+	if updated.Status != domain.DeviceStatusOffline {
+		t.Fatalf("Status = %v, want offline", updated.Status)
+	}
+}
+
+func TestDeviceService_Delete_RequiresUnbind(t *testing.T) {
+	svc, deviceRepo, _, _, _ := setupTestDeviceService()
+	device := createTestDevice(deviceRepo, "device-1", "tenant-1", domain.DeviceStatusActive)
+	lotID := "lot-1"
+	gateID := "gate-1"
+	device.ParkingLotID = &lotID
+	device.GateID = &gateID
+
+	err := svc.Delete(context.Background(), &service.DeleteDeviceRequest{
+		ID:       "device-1",
+		TenantID: "tenant-1",
+	})
+	if err == nil {
+		t.Fatal("Delete() error = nil, want DEVICE_MUST_UNBIND")
+	}
+	var domainErr *domain.DomainError
+	if !errors.As(err, &domainErr) || domainErr.Code != "DEVICE_MUST_UNBIND" {
+		t.Fatalf("error = %v, want DEVICE_MUST_UNBIND", err)
+	}
+}
+
+func TestDeviceService_Delete_Success(t *testing.T) {
+	svc, deviceRepo, _, _, _ := setupTestDeviceService()
+	createTestDevice(deviceRepo, "device-1", domain.PlatformTenantID, domain.DeviceStatusPending)
+
+	err := svc.Delete(context.Background(), &service.DeleteDeviceRequest{
+		ID:       "device-1",
+		TenantID: "",
+	})
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, ok := deviceRepo.devices["device-1"]; ok {
+		t.Fatal("device still exists after Delete()")
 	}
 }

--- a/parkhub-api/internal/service/interface.go
+++ b/parkhub-api/internal/service/interface.go
@@ -384,6 +384,12 @@ type DeviceService interface {
 	Bind(ctx context.Context, req *BindDeviceRequest) (*domain.Device, error)
 	// Unbind 解绑设备
 	Unbind(ctx context.Context, req *UnbindDeviceRequest) (*domain.Device, error)
+	// Disable 禁用设备
+	Disable(ctx context.Context, req *ChangeDeviceStatusRequest) (*domain.Device, error)
+	// Enable 启用设备
+	Enable(ctx context.Context, req *ChangeDeviceStatusRequest) (*domain.Device, error)
+	// Delete 删除设备
+	Delete(ctx context.Context, req *DeleteDeviceRequest) error
 	// GetStats 获取设备统计
 	GetStats(ctx context.Context, tenantID string) (*DeviceStatsResponse, error)
 }
@@ -436,6 +442,16 @@ type UnbindDeviceRequest struct {
 	OperatorIP       string
 	OperatorRole     string
 	OperatorTenantID string
+}
+
+type ChangeDeviceStatusRequest struct {
+	ID       string
+	TenantID string
+}
+
+type DeleteDeviceRequest struct {
+	ID       string
+	TenantID string
 }
 
 // DeviceStatsResponse 设备统计响应

--- a/parkhub-web/app/(dashboard)/device-management/page.tsx
+++ b/parkhub-web/app/(dashboard)/device-management/page.tsx
@@ -34,19 +34,24 @@ import {
   MapPin,
   Pencil,
   Plus,
+  Power,
   RefreshCw,
   Search,
   ShieldOff,
+  Trash2,
   TriangleAlert,
   Wifi,
   WifiOff,
   X,
 } from "lucide-react";
 import {
-  useCreateDevice,
   useBindDevice,
+  useCreateDevice,
+  useDeleteDevice,
+  useDisableDevice,
   useDevices,
   useDeviceStats,
+  useEnableDevice,
   useUnbindDevice,
   useUpdateDeviceName,
 } from "@/lib/device/hooks";
@@ -219,6 +224,9 @@ export default function DeviceManagementPage() {
   const { data: stats, isLoading: isLoadingStats } = useDeviceStats();
   const { isOperator } = usePermissions();
   const unbindMutation = useUnbindDevice();
+  const disableMutation = useDisableDevice();
+  const enableMutation = useEnableDevice();
+  const deleteMutation = useDeleteDevice();
 
   const devices = data?.items || [];
   const total = data?.total || 0;
@@ -247,6 +255,37 @@ export default function DeviceManagementPage() {
       refetch();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "解绑失败，请重试");
+    }
+  };
+
+  const handleToggleDisabled = async (device: Device) => {
+    const action = device.status === "disabled" ? "启用" : "禁用";
+    if (!window.confirm(`确认${action}设备 ${device.name || device.id} 吗？`)) return;
+
+    try {
+      if (device.status === "disabled") {
+        await enableMutation.mutateAsync(device.id);
+        toast.success("设备已启用");
+      } else {
+        await disableMutation.mutateAsync(device.id);
+        toast.success("设备已禁用");
+      }
+      refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `${action}失败，请重试`);
+    }
+  };
+
+  const handleDelete = async (device: Device) => {
+    if (device.parking_lot_id) return;
+    if (!window.confirm(`确认删除设备 ${device.name || device.id} 吗？此操作不可恢复。`)) return;
+
+    try {
+      await deleteMutation.mutateAsync(device.id);
+      toast.success("设备已删除");
+      refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "删除失败，请重试");
     }
   };
 
@@ -496,6 +535,8 @@ export default function DeviceManagementPage() {
                           onEdit={() => setEditDevice(device)}
                           onBind={() => setBindDevice(device)}
                           onUnbind={() => handleUnbind(device)}
+                          onToggleDisabled={() => handleToggleDisabled(device)}
+                          onDelete={() => handleDelete(device)}
                           index={index}
                         />
                       ))}
@@ -612,6 +653,8 @@ function DeviceRow({
   onEdit,
   onBind,
   onUnbind,
+  onToggleDisabled,
+  onDelete,
   index,
 }: {
   device: Device;
@@ -620,6 +663,8 @@ function DeviceRow({
   onEdit: () => void;
   onBind: () => void;
   onUnbind: () => void;
+  onToggleDisabled: () => void;
+  onDelete: () => void;
   index: number;
 }) {
   const runtimeStatus = getRuntimeDeviceStatus(device.status, device.last_heartbeat);
@@ -629,6 +674,8 @@ function DeviceRow({
   const heartbeatTimedOut = device.status === "active" && runtimeStatus === "offline";
   const canBind = canEdit && (device.status === "pending" || device.status === "active");
   const isBound = !!device.parking_lot_id;
+  const canDelete = !isBound;
+  const canEnable = device.status === "disabled";
 
   return (
     <TableRow
@@ -745,6 +792,21 @@ function DeviceRow({
               />
             )}
             <button
+              onClick={onToggleDisabled}
+              className={`inline-flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors ${
+                canEnable
+                  ? "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100"
+                  : "border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100"
+              }`}
+            >
+              {canEnable ? (
+                <Power className="h-3.5 w-3.5" />
+              ) : (
+                <ShieldOff className="h-3.5 w-3.5" />
+              )}
+              {canEnable ? "启用" : "禁用"}
+            </button>
+            <button
               onClick={onBind}
               disabled={!canBind}
               className={`inline-flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs font-medium transition-colors ${
@@ -763,6 +825,15 @@ function DeviceRow({
               >
                 <X className="h-3.5 w-3.5" />
                 解绑
+              </button>
+            )}
+            {canDelete && (
+              <button
+                onClick={onDelete}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-rose-200 bg-white px-3 py-1.5 text-xs font-medium text-rose-700 transition-colors hover:bg-rose-50"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                删除
               </button>
             )}
             <button

--- a/parkhub-web/lib/device/api.ts
+++ b/parkhub-web/lib/device/api.ts
@@ -271,6 +271,47 @@ export async function unbindDevice(
   return mapDeviceDetail(unwrapResponse(response));
 }
 
+export async function disableDevice(
+  id: string,
+  accessToken: string
+): Promise<DeviceDetail> {
+  const response = await request<DeviceRaw | ApiEnvelope<DeviceRaw>>(
+    `/api/v1/devices/${id}/disable`,
+    {
+      method: 'POST',
+    },
+    accessToken
+  );
+  return mapDeviceDetail(unwrapResponse(response));
+}
+
+export async function enableDevice(
+  id: string,
+  accessToken: string
+): Promise<DeviceDetail> {
+  const response = await request<DeviceRaw | ApiEnvelope<DeviceRaw>>(
+    `/api/v1/devices/${id}/enable`,
+    {
+      method: 'POST',
+    },
+    accessToken
+  );
+  return mapDeviceDetail(unwrapResponse(response));
+}
+
+export async function deleteDevice(
+  id: string,
+  accessToken: string
+): Promise<void> {
+  await request<{ code: number; message: string }>(
+    `/api/v1/devices/${id}`,
+    {
+      method: 'DELETE',
+    },
+    accessToken
+  );
+}
+
 export async function controlDevice(
   id: string,
   req: ControlDeviceRequest,

--- a/parkhub-web/lib/device/hooks.ts
+++ b/parkhub-web/lib/device/hooks.ts
@@ -114,6 +114,56 @@ export function useUnbindDevice() {
   });
 }
 
+export function useDisableDevice() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const accessToken = await getValidAccessToken();
+      if (!accessToken) throw new Error('未登录');
+      return api.disableDevice(id, accessToken);
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: deviceKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: deviceKeys.stats() });
+      queryClient.invalidateQueries({ queryKey: deviceKeys.detail(id) });
+    },
+  });
+}
+
+export function useEnableDevice() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const accessToken = await getValidAccessToken();
+      if (!accessToken) throw new Error('未登录');
+      return api.enableDevice(id, accessToken);
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: deviceKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: deviceKeys.stats() });
+      queryClient.invalidateQueries({ queryKey: deviceKeys.detail(id) });
+    },
+  });
+}
+
+export function useDeleteDevice() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const accessToken = await getValidAccessToken();
+      if (!accessToken) throw new Error('未登录');
+      return api.deleteDevice(id, accessToken);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: deviceKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: deviceKeys.stats() });
+    },
+  });
+}
+
 export function useControlDevice() {
   return useMutation({
     mutationFn: async ({ id, command }: { id: string; command: ControlDeviceRequest['command'] }) => {


### PR DESCRIPTION
## 背景
实现 Issue #19「设备状态管理」的剩余功能，补齐后端状态接口、软删除流程与前端操作入口。

## 实现内容
- 新增设备状态管理 API：
  - `POST /api/v1/devices/:id/disable`
  - `POST /api/v1/devices/:id/enable`
  - `DELETE /api/v1/devices/:id`
- 权限控制：以上 3 个接口均限制为 `platform_admin` / `tenant_admin`
- 启用逻辑：仅允许从 `disabled` 启用，并按最后心跳时间恢复为 `active` 或 `offline`
- 删除逻辑：删除前必须先解绑（`parking_lot_id` / `gate_id` 为空），否则返回业务错误
- 软删除落库：通过设置 `deleted_at` 实现
- 前端设备管理页：
  - 新增禁用/启用按钮（根据当前状态显示）
  - 新增删除按钮（仅未绑定设备显示）
  - 新增对应 hooks / API 调用与刷新逻辑

## 验收对应
- [x] 禁用接口将设备状态设为 `disabled`
- [x] 启用接口从 `disabled` 恢复到 `active/offline`（心跳驱动）
- [x] 删除接口软删除设备（设置 `deleted_at`）
- [x] 删除前校验设备必须先解绑
- [x] 仅 admin 可操作
- [x] 前端禁用/启用按钮按状态显示
- [x] 前端删除按钮仅已解绑设备显示
- [x] 单元测试通过

## 测试
- `cd parkhub-api && go test ./...`
- `cd parkhub-web && pnpm lint`

Closes #19
