### PR TITLE
feat(device): 实现设备详情页与控制日志分页

### DIFF
--- a/parkhub-api/internal/handler/device_handler.go
+++ b/parkhub-api/internal/handler/device_handler.go
@@ -300,6 +300,46 @@ func (h *DeviceHandler) GetStats(c *gin.Context) {
 	})
 }
 
+func (h *DeviceHandler) ListControlLogs(c *gin.Context) {
+	deviceID := c.Param("id")
+	tenantID := c.GetString("tenant_id")
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+
+	resp, err := h.deviceControlService.ListLogs(c.Request.Context(), &service.ListDeviceControlLogsRequest{
+		DeviceID: deviceID,
+		TenantID: tenantID,
+		Page:     page,
+		PageSize: pageSize,
+	})
+	if err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	items := make([]*dto.DeviceControlLogItem, len(resp.Items))
+	for i, item := range resp.Items {
+		items[i] = &dto.DeviceControlLogItem{
+			ID:           item.ID,
+			OperatorID:   item.OperatorID,
+			OperatorName: item.OperatorName,
+			Command:      item.Command,
+			CreatedAt:    item.CreatedAt,
+		}
+	}
+
+	c.JSON(http.StatusOK, dto.Response{
+		Code:    0,
+		Message: "success",
+		Data: dto.DeviceControlLogListData{
+			Items:    items,
+			Total:    resp.Total,
+			Page:     resp.Page,
+			PageSize: resp.PageSize,
+		},
+	})
+}
+
 func (h *DeviceHandler) Control(c *gin.Context) {
 	deviceID := c.Param("id")
 	tenantID := c.GetString("tenant_id")

--- a/parkhub-api/internal/handler/device_handler_test.go
+++ b/parkhub-api/internal/handler/device_handler_test.go
@@ -71,10 +71,19 @@ func (s *stubDeviceService) Delete(ctx context.Context, req *service.DeleteDevic
 }
 
 // stubDeviceControlService is a stub implementation for the tests
-type stubDeviceControlService struct{}
+type stubDeviceControlService struct {
+	listLogsFn func(ctx context.Context, req *service.ListDeviceControlLogsRequest) (*service.ListDeviceControlLogsResponse, error)
+}
 
 func (s *stubDeviceControlService) Control(ctx context.Context, req *service.ControlDeviceRequest) (*service.ControlDeviceResponse, error) {
 	return &service.ControlDeviceResponse{Success: true}, nil
+}
+
+func (s *stubDeviceControlService) ListLogs(ctx context.Context, req *service.ListDeviceControlLogsRequest) (*service.ListDeviceControlLogsResponse, error) {
+	if s.listLogsFn == nil {
+		return &service.ListDeviceControlLogsResponse{}, nil
+	}
+	return s.listLogsFn(ctx, req)
 }
 
 func TestDeviceHandler_Bind_Success(t *testing.T) {
@@ -174,6 +183,57 @@ func TestDeviceHandler_Delete_MapsDomainError(t *testing.T) {
 		t.Fatalf("status = %v, want 400", resp.Code)
 	}
 	if !bytes.Contains(resp.Body.Bytes(), []byte(`"code":40003`)) {
+		t.Fatalf("body = %s", resp.Body.String())
+	}
+}
+
+func TestDeviceHandler_ListControlLogs_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	svc := &stubDeviceService{}
+	controlSvc := &stubDeviceControlService{
+		listLogsFn: func(ctx context.Context, req *service.ListDeviceControlLogsRequest) (*service.ListDeviceControlLogsResponse, error) {
+			if req.DeviceID != "device-1" {
+				t.Fatalf("DeviceID = %v, want device-1", req.DeviceID)
+			}
+			if req.Page != 2 || req.PageSize != 20 {
+				t.Fatalf("page/pageSize = %d/%d, want 2/20", req.Page, req.PageSize)
+			}
+			return &service.ListDeviceControlLogsResponse{
+				Items: []*service.DeviceControlLogItem{
+					{
+						ID:           "log-1",
+						OperatorID:   "user-1",
+						OperatorName: "张三",
+						Command:      "open_gate",
+						CreatedAt:    "2026-03-19T10:00:00Z",
+					},
+				},
+				Total:    21,
+				Page:     2,
+				PageSize: 20,
+			}, nil
+		},
+	}
+	handler := NewDeviceHandler(svc, controlSvc)
+
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set("tenant_id", "tenant-1")
+	})
+	router.GET("/devices/:id/control-logs", handler.ListControlLogs)
+
+	req := httptest.NewRequest(http.MethodGet, "/devices/device-1/control-logs?page=2&page_size=20", nil)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status = %v, want 200", resp.Code)
+	}
+	if !bytes.Contains(resp.Body.Bytes(), []byte(`"total":21`)) {
+		t.Fatalf("body = %s", resp.Body.String())
+	}
+	if !bytes.Contains(resp.Body.Bytes(), []byte(`"operator_name":"张三"`)) {
 		t.Fatalf("body = %s", resp.Body.String())
 	}
 }

--- a/parkhub-api/internal/handler/dto/device.go
+++ b/parkhub-api/internal/handler/dto/device.go
@@ -68,6 +68,21 @@ type DeviceStatsData struct {
 	Disabled int64 `json:"disabled"`
 }
 
+type DeviceControlLogItem struct {
+	ID           string `json:"id"`
+	OperatorID   string `json:"operator_id"`
+	OperatorName string `json:"operator_name"`
+	Command      string `json:"command"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type DeviceControlLogListData struct {
+	Items    []*DeviceControlLogItem `json:"items"`
+	Total    int64                   `json:"total"`
+	Page     int                     `json:"page"`
+	PageSize int                     `json:"page_size"`
+}
+
 // ToDeviceListItemDTO converts service layer item to DTO.
 func ToDeviceListItemDTO(item *service.DeviceListItem) *DeviceListItem {
 	return &DeviceListItem{

--- a/parkhub-api/internal/router/router.go
+++ b/parkhub-api/internal/router/router.go
@@ -259,6 +259,9 @@ func (r *Router) setupDeviceRoutes(rg *gin.RouterGroup) {
 		// POST /api/v1/devices/:id/control - 远程控制设备
 		devices.POST("/:id/control", r.deviceHandler.Control)
 
+		// GET /api/v1/devices/:id/control-logs - 获取设备控制日志
+		devices.GET("/:id/control-logs", r.deviceHandler.ListControlLogs)
+
 		// POST /api/v1/devices/:id/disable - 禁用设备（仅admin）
 		devices.POST("/:id/disable", middleware.RequireRoles("platform_admin", "tenant_admin"), r.deviceHandler.Disable)
 

--- a/parkhub-api/internal/service/impl/device_control_service.go
+++ b/parkhub-api/internal/service/impl/device_control_service.go
@@ -99,6 +99,51 @@ func (s *deviceControlServiceImpl) Control(ctx context.Context, req *service.Con
 	return &service.ControlDeviceResponse{Success: true}, nil
 }
 
+func (s *deviceControlServiceImpl) ListLogs(ctx context.Context, req *service.ListDeviceControlLogsRequest) (*service.ListDeviceControlLogsResponse, error) {
+	device, err := s.deviceRepo.FindByID(ctx, req.DeviceID)
+	if err != nil {
+		if err == domain.ErrDeviceNotFound {
+			return nil, &domain.DomainError{Code: "DEVICE_NOT_FOUND", Message: err.Error()}
+		}
+		return nil, err
+	}
+	if req.TenantID != "" && device.TenantID != req.TenantID {
+		return nil, &domain.DomainError{Code: "FORBIDDEN", Message: "无权访问该设备控制日志"}
+	}
+
+	page := req.Page
+	if page <= 0 {
+		page = 1
+	}
+	pageSize := req.PageSize
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+
+	logs, total, err := s.controlLogRepo.FindByDeviceID(ctx, req.DeviceID, page, pageSize)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]*service.DeviceControlLogItem, len(logs))
+	for i, log := range logs {
+		items[i] = &service.DeviceControlLogItem{
+			ID:           log.ID,
+			OperatorID:   log.OperatorID,
+			OperatorName: log.OperatorName,
+			Command:      log.Command,
+			CreatedAt:    log.CreatedAt.Format(time.RFC3339),
+		}
+	}
+
+	return &service.ListDeviceControlLogsResponse{
+		Items:    items,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	}, nil
+}
+
 func (s *deviceControlServiceImpl) isDeviceOnline(device *domain.Device) bool {
 	if device.Status != domain.DeviceStatusActive {
 		return false

--- a/parkhub-api/internal/service/impl/device_control_service_test.go
+++ b/parkhub-api/internal/service/impl/device_control_service_test.go
@@ -3,6 +3,7 @@ package impl
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -90,6 +91,7 @@ func (m *mockDeviceRepoForControl) UnbindByGateID(ctx context.Context, gateID st
 type mockDeviceControlLogRepo struct {
 	logs      []*domain.DeviceControlLog
 	createErr error
+	findErr   error
 }
 
 type mockAuditLogServiceForControl struct {
@@ -122,7 +124,25 @@ func (m *mockDeviceControlLogRepo) Create(ctx context.Context, log *domain.Devic
 }
 
 func (m *mockDeviceControlLogRepo) FindByDeviceID(ctx context.Context, deviceID string, page, pageSize int) ([]*domain.DeviceControlLog, int64, error) {
-	return nil, 0, nil
+	if m.findErr != nil {
+		return nil, 0, m.findErr
+	}
+	deviceLogs := make([]*domain.DeviceControlLog, 0)
+	for _, log := range m.logs {
+		if log.DeviceID == deviceID {
+			deviceLogs = append(deviceLogs, log)
+		}
+	}
+	total := int64(len(deviceLogs))
+	start := (page - 1) * pageSize
+	if start > len(deviceLogs) {
+		start = len(deviceLogs)
+	}
+	end := start + pageSize
+	if end > len(deviceLogs) {
+		end = len(deviceLogs)
+	}
+	return deviceLogs[start:end], total, nil
 }
 
 // Test helpers
@@ -431,6 +451,61 @@ func TestDeviceControlService_Control_WritesAuditLog(t *testing.T) {
 	}
 	if log.IP != "127.0.0.1" {
 		t.Fatalf("IP = %v, want 127.0.0.1", log.IP)
+	}
+}
+
+func TestDeviceControlService_ListLogs_Pagination(t *testing.T) {
+	svc, deviceRepo, logRepo := setupTestDeviceControlService()
+	createOnlineDevice(deviceRepo, "device-1", "tenant-1")
+	now := time.Now()
+	for i := 0; i < 25; i++ {
+		logRepo.logs = append(logRepo.logs, &domain.DeviceControlLog{
+			ID:           fmt.Sprintf("log-%d", i+1),
+			TenantID:     "tenant-1",
+			DeviceID:     "device-1",
+			OperatorID:   "user-1",
+			OperatorName: "测试用户",
+			Command:      "open_gate",
+			CreatedAt:    now.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	resp, err := svc.ListLogs(context.Background(), &service.ListDeviceControlLogsRequest{
+		DeviceID: "device-1",
+		TenantID: "tenant-1",
+		Page:     2,
+		PageSize: 20,
+	})
+	if err != nil {
+		t.Fatalf("ListLogs() error = %v", err)
+	}
+	if resp.Total != 25 {
+		t.Fatalf("Total = %d, want 25", resp.Total)
+	}
+	if resp.Page != 2 || resp.PageSize != 20 {
+		t.Fatalf("Page/PageSize = %d/%d, want 2/20", resp.Page, resp.PageSize)
+	}
+	if len(resp.Items) != 5 {
+		t.Fatalf("len(Items) = %d, want 5", len(resp.Items))
+	}
+}
+
+func TestDeviceControlService_ListLogs_Forbidden(t *testing.T) {
+	svc, deviceRepo, _ := setupTestDeviceControlService()
+	createOnlineDevice(deviceRepo, "device-1", "tenant-1")
+
+	_, err := svc.ListLogs(context.Background(), &service.ListDeviceControlLogsRequest{
+		DeviceID: "device-1",
+		TenantID: "tenant-2",
+		Page:     1,
+		PageSize: 20,
+	})
+	if err == nil {
+		t.Fatal("ListLogs() should return forbidden error")
+	}
+	var domainErr *domain.DomainError
+	if !errors.As(err, &domainErr) || domainErr.Code != "FORBIDDEN" {
+		t.Fatalf("error = %v, want FORBIDDEN", err)
 	}
 }
 

--- a/parkhub-api/internal/service/interface.go
+++ b/parkhub-api/internal/service/interface.go
@@ -516,6 +516,7 @@ type UpdateGateRequest struct {
 
 type DeviceControlService interface {
 	Control(ctx context.Context, req *ControlDeviceRequest) (*ControlDeviceResponse, error)
+	ListLogs(ctx context.Context, req *ListDeviceControlLogsRequest) (*ListDeviceControlLogsResponse, error)
 }
 
 type ControlDeviceRequest struct {
@@ -529,6 +530,28 @@ type ControlDeviceRequest struct {
 
 type ControlDeviceResponse struct {
 	Success bool
+}
+
+type ListDeviceControlLogsRequest struct {
+	DeviceID string
+	TenantID string
+	Page     int
+	PageSize int
+}
+
+type DeviceControlLogItem struct {
+	ID           string
+	OperatorID   string
+	OperatorName string
+	Command      string
+	CreatedAt    string
+}
+
+type ListDeviceControlLogsResponse struct {
+	Items    []*DeviceControlLogItem
+	Total    int64
+	Page     int
+	PageSize int
 }
 
 // BillingRuleService 计费规则服务接口

--- a/parkhub-web/app/(dashboard)/device-management/[id]/page.tsx
+++ b/parkhub-web/app/(dashboard)/device-management/[id]/page.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  ArrowLeft,
+  CalendarClock,
+  ChevronLeft,
+  ChevronRight,
+  DoorOpen,
+  Loader2,
+  ShieldOff,
+  ToggleLeft,
+  UserCircle2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useParams } from "next/navigation";
+import {
+  useDevice,
+  useDeviceControlLogs,
+  useDisableDevice,
+  useEnableDevice,
+  useUnbindDevice,
+} from "@/lib/device/hooks";
+import { getRuntimeDeviceStatus } from "@/lib/device/status";
+import type { DeviceStatus } from "@/lib/device/types";
+import { useGates, useParkingLot } from "@/lib/parking-lot/hooks";
+import { usePermissions } from "@/lib/auth/hooks";
+import { DeviceControlButton } from "@/components/device";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const PAGE_SIZE = 20;
+
+const STATUS_LABEL: Record<DeviceStatus, string> = {
+  active: "在线",
+  offline: "离线",
+  pending: "待分配",
+  disabled: "已禁用",
+};
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "暂无";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "暂无";
+  return date.toLocaleString("zh-CN", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function toCommandLabel(command: string): string {
+  if (command === "open_gate") return "抬杆";
+  return command || "-";
+}
+
+export default function DeviceDetailPage() {
+  const params = useParams<{ id: string }>();
+  const deviceID = Array.isArray(params.id) ? params.id[0] : params.id;
+  const [page, setPage] = useState(1);
+
+  const { isOperator } = usePermissions();
+  const { data: device, isLoading, error, refetch } = useDevice(deviceID || "");
+  const {
+    data: logs,
+    isLoading: logsLoading,
+    refetch: refetchLogs,
+  } = useDeviceControlLogs(deviceID || "", page, PAGE_SIZE);
+  const { data: parkingLot } = useParkingLot(device?.parking_lot_id ?? "");
+  const { data: gates = [] } = useGates(device?.parking_lot_id ?? "");
+
+  const disableMutation = useDisableDevice();
+  const enableMutation = useEnableDevice();
+  const unbindMutation = useUnbindDevice();
+
+  const gateName = useMemo(() => {
+    if (!device?.gate_id) return "未绑定";
+    const target = gates.find((item) => item.id === device.gate_id);
+    return target?.name || device.gate_id;
+  }, [device?.gate_id, gates]);
+
+  if (!deviceID) {
+    return <div className="p-6 text-sm text-rose-600">设备 ID 无效</div>;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[60vh] items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (error || !device) {
+    return (
+      <div className="p-6">
+        <Link
+          href="/device-management"
+          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          返回设备列表
+        </Link>
+        <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700">
+          {error instanceof Error ? error.message : "设备不存在或无权限访问"}
+        </div>
+      </div>
+    );
+  }
+
+  const runtimeStatus = getRuntimeDeviceStatus(device.status, device.last_heartbeat);
+  const isBound = !!device.parking_lot_id;
+  const canEditAdminActions = !isOperator;
+  const isStatusLoading = disableMutation.isPending || enableMutation.isPending;
+  const isUnbindLoading = unbindMutation.isPending;
+
+  const totalLogs = logs?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalLogs / PAGE_SIZE));
+  const logItems = logs?.items ?? [];
+
+  const handleToggleStatus = async () => {
+    if (!canEditAdminActions) return;
+    const action = device.status === "disabled" ? "启用" : "禁用";
+    if (!window.confirm(`确认${action}设备 ${device.name || device.id} 吗？`)) return;
+
+    try {
+      if (device.status === "disabled") {
+        await enableMutation.mutateAsync(device.id);
+        toast.success("设备已启用");
+      } else {
+        await disableMutation.mutateAsync(device.id);
+        toast.success("设备已禁用");
+      }
+      await refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : `${action}失败，请重试`);
+    }
+  };
+
+  const handleUnbind = async () => {
+    if (!isBound || !canEditAdminActions) return;
+    if (!window.confirm(`确认解绑设备 ${device.name || device.id} 吗？`)) return;
+
+    try {
+      await unbindMutation.mutateAsync(device.id);
+      toast.success("设备解绑成功");
+      await refetch();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "解绑失败，请重试");
+    }
+  };
+
+  return (
+    <div className="px-4 py-5 md:px-8 md:py-6">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Link
+            href="/device-management"
+            className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            返回设备列表
+          </Link>
+          <h1 className="mt-2 text-2xl font-semibold text-slate-900">设备详情</h1>
+        </div>
+        <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700">
+          当前状态：{STATUS_LABEL[runtimeStatus]}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <section className="rounded-2xl border border-slate-200 bg-white p-4 md:p-5">
+            <h2 className="mb-3 text-sm font-semibold text-slate-900">基础信息</h2>
+            <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+              <div>
+                <p className="text-slate-400">设备名称</p>
+                <p className="mt-1 text-slate-800">{device.name || "未命名设备"}</p>
+              </div>
+              <div>
+                <p className="text-slate-400">设备序列号</p>
+                <p className="mt-1 font-mono text-slate-800">{device.id}</p>
+              </div>
+              <div>
+                <p className="text-slate-400">运行状态</p>
+                <p className="mt-1 text-slate-800">{STATUS_LABEL[runtimeStatus]}</p>
+              </div>
+              <div>
+                <p className="text-slate-400">固件版本</p>
+                <p className="mt-1 text-slate-800">{device.firmware_version || "未知版本"}</p>
+              </div>
+              <div>
+                <p className="text-slate-400">最后心跳</p>
+                <p className="mt-1 text-slate-800">{formatDateTime(device.last_heartbeat)}</p>
+              </div>
+              <div>
+                <p className="text-slate-400">创建时间</p>
+                <p className="mt-1 text-slate-800">{formatDateTime(device.created_at)}</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-4 md:p-5">
+            <h2 className="mb-3 text-sm font-semibold text-slate-900">位置信息</h2>
+            <div className="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
+              <div>
+                <p className="text-slate-400">所属车场</p>
+                <p className="mt-1 text-slate-800">
+                  {parkingLot?.name || device.parking_lot_id || "未绑定"}
+                </p>
+              </div>
+              <div>
+                <p className="text-slate-400">所属出入口</p>
+                <p className="mt-1 text-slate-800">{gateName}</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <section className="rounded-2xl border border-slate-200 bg-white p-4 md:p-5">
+          <h2 className="mb-3 text-sm font-semibold text-slate-900">控制操作</h2>
+          <div className="flex flex-wrap gap-2">
+            <DeviceControlButton
+              deviceId={device.id}
+              deviceName={device.name || device.id}
+              status={device.status}
+              lastHeartbeat={device.last_heartbeat}
+              onSuccess={() => {
+                refetchLogs();
+              }}
+            />
+            <button
+              onClick={handleToggleStatus}
+              disabled={isStatusLoading || !canEditAdminActions}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <ToggleLeft className="h-3.5 w-3.5" />
+              {device.status === "disabled" ? "启用设备" : "禁用设备"}
+            </button>
+            {isBound && (
+              <button
+                onClick={handleUnbind}
+                disabled={isUnbindLoading || !canEditAdminActions}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-rose-200 bg-rose-50 px-3 py-1.5 text-xs font-medium text-rose-700 transition-colors hover:bg-rose-100 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <DoorOpen className="h-3.5 w-3.5" />
+                解绑设备
+              </button>
+            )}
+          </div>
+          {isOperator && (
+            <p className="mt-3 text-xs text-slate-400">
+              当前角色为操作员，仅可执行抬杆操作。
+            </p>
+          )}
+        </section>
+      </div>
+
+      <section className="mt-4 rounded-2xl border border-slate-200 bg-white p-4 md:p-5">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-slate-900">控制日志</h2>
+          <span className="text-xs text-slate-400">每页 {PAGE_SIZE} 条</span>
+        </div>
+
+        {logsLoading ? (
+          <div className="flex h-28 items-center justify-center">
+            <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+          </div>
+        ) : logItems.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-8 text-center text-sm text-slate-400">
+            暂无控制日志
+          </div>
+        ) : (
+          <>
+            <div className="hidden overflow-x-auto md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>时间</TableHead>
+                    <TableHead>操作人</TableHead>
+                    <TableHead>指令</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {logItems.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="text-sm text-slate-700">
+                        <div className="inline-flex items-center gap-1">
+                          <CalendarClock className="h-3.5 w-3.5 text-slate-400" />
+                          {formatDateTime(item.created_at)}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-slate-700">
+                        <div className="inline-flex items-center gap-1">
+                          <UserCircle2 className="h-3.5 w-3.5 text-slate-400" />
+                          {item.operator_name || item.operator_id}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-slate-700">
+                        <div className="inline-flex items-center gap-1">
+                          <ShieldOff className="h-3.5 w-3.5 text-slate-400" />
+                          {toCommandLabel(item.command)}
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="space-y-3 md:hidden">
+              {logItems.map((item) => (
+                <div key={item.id} className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                  <p className="text-sm font-medium text-slate-800">{toCommandLabel(item.command)}</p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    操作人：{item.operator_name || item.operator_id}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-400">{formatDateTime(item.created_at)}</p>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+            disabled={page <= 1}
+            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            上一页
+          </button>
+          <span className="text-xs text-slate-500">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+            disabled={page >= totalPages}
+            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            下一页
+            <ChevronRight className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/parkhub-web/app/(dashboard)/device-management/page.tsx
+++ b/parkhub-web/app/(dashboard)/device-management/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Icon } from "@/components/icons/FontAwesome";
@@ -783,6 +784,13 @@ function DeviceRow({
       <TableCell className="pr-6 py-4 text-right">
         {canEdit ? (
           <div className="flex justify-end gap-2">
+            <Link
+              href={`/device-management/${device.id}`}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:border-brand-200 hover:bg-brand-50 hover:text-brand-700"
+            >
+              <HardDrive className="h-3.5 w-3.5" />
+              详情
+            </Link>
             {canControl && (
               <DeviceControlButton
                 deviceId={device.id}
@@ -846,6 +854,13 @@ function DeviceRow({
           </div>
         ) : (
           <div className="flex justify-end gap-2">
+            <Link
+              href={`/device-management/${device.id}`}
+              className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:border-brand-200 hover:bg-brand-50 hover:text-brand-700"
+            >
+              <HardDrive className="h-3.5 w-3.5" />
+              详情
+            </Link>
             {canControl && (
               <DeviceControlButton
                 deviceId={device.id}

--- a/parkhub-web/lib/device/api.ts
+++ b/parkhub-web/lib/device/api.ts
@@ -9,6 +9,8 @@ import type {
   BindDeviceRequest,
   ControlDeviceRequest,
   ControlDeviceResponse,
+  DeviceControlLogItem,
+  DeviceControlLogListResponse,
 } from './types';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
@@ -45,6 +47,25 @@ type DeviceListRaw = {
   page?: number;
   page_size?: number;
   Items?: DeviceRaw[];
+  Total?: number;
+  Page?: number;
+  PageSize?: number;
+};
+
+type DeviceControlLogRaw = Partial<DeviceControlLogItem> & {
+  ID?: string;
+  OperatorID?: string;
+  OperatorName?: string;
+  Command?: string;
+  CreatedAt?: string;
+};
+
+type DeviceControlLogListRaw = {
+  items?: DeviceControlLogRaw[];
+  total?: number;
+  page?: number;
+  page_size?: number;
+  Items?: DeviceControlLogRaw[];
   Total?: number;
   Page?: number;
   PageSize?: number;
@@ -129,6 +150,25 @@ function mapDeviceDetail(raw: DeviceRaw): DeviceDetail {
 function mapDeviceList(raw: DeviceListRaw): DeviceListResponse {
   return {
     items: (raw.items ?? raw.Items ?? []).map(mapDevice),
+    total: raw.total ?? raw.Total ?? 0,
+    page: raw.page ?? raw.Page ?? 1,
+    page_size: raw.page_size ?? raw.PageSize ?? 20,
+  };
+}
+
+function mapDeviceControlLog(raw: DeviceControlLogRaw): DeviceControlLogItem {
+  return {
+    id: raw.id ?? raw.ID ?? '',
+    operator_id: raw.operator_id ?? raw.OperatorID ?? '',
+    operator_name: raw.operator_name ?? raw.OperatorName ?? '',
+    command: raw.command ?? raw.Command ?? '',
+    created_at: raw.created_at ?? raw.CreatedAt ?? '',
+  };
+}
+
+function mapDeviceControlLogList(raw: DeviceControlLogListRaw): DeviceControlLogListResponse {
+  return {
+    items: (raw.items ?? raw.Items ?? []).map(mapDeviceControlLog),
     total: raw.total ?? raw.Total ?? 0,
     page: raw.page ?? raw.Page ?? 1,
     page_size: raw.page_size ?? raw.PageSize ?? 20,
@@ -223,6 +263,24 @@ export async function getDevice(
     accessToken
   );
   return mapDeviceDetail(unwrapResponse(response));
+}
+
+export async function getDeviceControlLogs(
+  id: string,
+  page: number,
+  pageSize: number,
+  accessToken: string
+): Promise<DeviceControlLogListResponse> {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+  });
+  const response = await request<DeviceControlLogListRaw | ApiEnvelope<DeviceControlLogListRaw>>(
+    `/api/v1/devices/${id}/control-logs?${params.toString()}`,
+    {},
+    accessToken
+  );
+  return mapDeviceControlLogList(unwrapResponse(response));
 }
 
 export async function updateDeviceName(

--- a/parkhub-web/lib/device/hooks.ts
+++ b/parkhub-web/lib/device/hooks.ts
@@ -12,6 +12,7 @@ export const deviceKeys = {
   details: () => [...deviceKeys.all, 'detail'] as const,
   detail: (id: string) => [...deviceKeys.details(), id] as const,
   stats: () => [...deviceKeys.all, 'stats'] as const,
+  controlLogs: (id: string, page: number, pageSize: number) => [...deviceKeys.all, 'control-logs', id, page, pageSize] as const,
 };
 
 export function useDevices(filter: DeviceFilter) {
@@ -43,6 +44,18 @@ export function useDevice(id: string) {
       const accessToken = await getValidAccessToken();
       if (!accessToken) throw new Error('未登录');
       return api.getDevice(id, accessToken);
+    },
+    enabled: !!id,
+  });
+}
+
+export function useDeviceControlLogs(id: string, page: number, pageSize: number = 20) {
+  return useQuery({
+    queryKey: deviceKeys.controlLogs(id, page, pageSize),
+    queryFn: async () => {
+      const accessToken = await getValidAccessToken();
+      if (!accessToken) throw new Error('未登录');
+      return api.getDeviceControlLogs(id, page, pageSize, accessToken);
     },
     enabled: !!id,
   });

--- a/parkhub-web/lib/device/types.ts
+++ b/parkhub-web/lib/device/types.ts
@@ -74,3 +74,18 @@ export interface ControlDeviceRequest {
 export interface ControlDeviceResponse {
   success: boolean;
 }
+
+export interface DeviceControlLogItem {
+  id: string;
+  operator_id: string;
+  operator_name: string;
+  command: string;
+  created_at: string;
+}
+
+export interface DeviceControlLogListResponse {
+  items: DeviceControlLogItem[];
+  total: number;
+  page: number;
+  page_size: number;
+}


### PR DESCRIPTION
## 背景
实现 Issue #21「设备详情页」，补齐设备详情展示、控制日志分页 API 与前端页面。

## 实现内容
- 后端新增 `GET /api/v1/devices/:id/control-logs`
  - 支持分页参数 `page` / `page_size`
  - 默认每页 20 条
  - 多租户隔离校验（非平台管理员仅可查看本租户设备）
- 前端新增页面 `/device-management/:id`
  - 路由文件：`app/(dashboard)/device-management/[id]/page.tsx`
  - 展示基础信息：名称、序列号、状态、固件版本、最后心跳、创建时间
  - 展示位置信息：所属车场、所属出入口
  - 控制按钮：抬杆、禁用/启用、解绑
  - 控制日志：时间、操作人、指令
  - 控制日志分页：每页 20 条
  - 响应式布局：桌面表格 + 移动端卡片
- 设备列表页增加“详情”入口，跳转到详情页

## 验收对应
- [x] 设备详情页展示所有基础信息
- [x] 设备详情页展示位置信息（车场、出入口）
- [x] 抬杆按钮：设备在线时可点击
- [x] 禁用/启用按钮：根据当前状态显示
- [x] 解绑按钮：已绑定设备显示
- [x] 控制日志列表：展示时间、操作人、指令
- [x] 控制日志支持分页（每页20条）
- [x] `GET /api/v1/devices/:id/control-logs` 返回分页数据
- [x] 权限控制：所有角色可查看
- [x] 页面响应式布局

## 测试
- `cd parkhub-api && go test ./...`
- `cd parkhub-web && pnpm lint`

Closes #21
