### PR TITLE
fix(web): Middleware JWT 签名验证

### DIFF
--- a/parkhub-web/middleware.ts
+++ b/parkhub-web/middleware.ts
@@ -1,3 +1,4 @@
+import { jwtVerify } from 'jose';
 import { NextRequest, NextResponse } from 'next/server';
 import type { UserRole } from './lib/auth/types';
 
@@ -23,7 +24,7 @@ const ROUTE_PERMISSIONS: Record<string, RoutePermission> = {
 const PUBLIC_ROUTES = ['/login', '/payment'];
 
 // ──────────────────────────────────────────────
-// JWT decode helpers (no crypto – just parse payload)
+// JWT verification with jose (Edge Runtime compatible)
 // ──────────────────────────────────────────────
 
 interface JwtPayload {
@@ -33,7 +34,7 @@ interface JwtPayload {
 }
 
 // Token cache for performance optimization
-// Caches parsed JWT payloads for 5 minutes to avoid repeated parsing
+// Caches verified JWT payloads for 5 minutes to avoid repeated verification
 // Uses LRU (Least Recently Used) eviction when cache is full
 const tokenCache = new Map<string, { payload: JwtPayload; expiry: number; lastAccess: number }>();
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -54,66 +55,70 @@ if (typeof setInterval !== 'undefined') {
 // Evict least recently used entries when cache is full
 function evictLRU(): void {
   if (tokenCache.size < MAX_CACHE_SIZE) return;
-  
+
   let oldestKey: string | null = null;
   let oldestAccess = Infinity;
-  
+
   for (const [key, value] of tokenCache.entries()) {
     if (value.lastAccess < oldestAccess) {
       oldestAccess = value.lastAccess;
       oldestKey = key;
     }
   }
-  
+
   if (oldestKey) {
     tokenCache.delete(oldestKey);
   }
 }
 
-function parseJwtPayload(token: string): JwtPayload | null {
-  // Check cache first
+// Lazily initialize the secret key (recreated per cold start)
+let secretKey: Uint8Array | null = null;
+
+function getSecretKey(): Uint8Array {
+  if (!secretKey) {
+    secretKey = new TextEncoder().encode(process.env.JWT_SECRET);
+  }
+  return secretKey;
+}
+
+async function verifyJwtToken(token: string): Promise<JwtPayload | null> {
+  // Check cache first — skip crypto verification for recently verified tokens
   const cached = tokenCache.get(token);
   if (cached && cached.expiry > Date.now()) {
-    // Update last access time
     cached.lastAccess = Date.now();
     return cached.payload;
   }
 
   try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return null;
-    const payload = parts[1];
-    // base64url decode
-    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
-    const json = atob(base64);
-    const result = JSON.parse(json) as JwtPayload;
-    
+    const { payload } = await jwtVerify(token, getSecretKey());
+
+    const result: JwtPayload = {
+      sub: payload.sub as string | undefined,
+      role: payload.role as UserRole | undefined,
+      exp: payload.exp,
+    };
+
     // Evict LRU if cache is full
     evictLRU();
-    
-    // Cache the result
+
+    // Cache the verified result
     tokenCache.set(token, {
       payload: result,
       expiry: Date.now() + CACHE_TTL_MS,
-      lastAccess: Date.now()
+      lastAccess: Date.now(),
     });
-    
+
     return result;
   } catch {
     return null;
   }
 }
 
-function isTokenExpired(payload: JwtPayload): boolean {
-  if (!payload.exp) return true;
-  return Date.now() / 1000 >= payload.exp;
-}
-
 // ──────────────────────────────────────────────
 // Middleware
 // ──────────────────────────────────────────────
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Allow public routes
@@ -140,15 +145,15 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  // Parse JWT payload
-  const payload = parseJwtPayload(accessToken);
+  // Verify JWT signature and parse payload
+  const payload = await verifyJwtToken(accessToken);
 
-  // Invalid or expired token → redirect to login
-  if (!payload || isTokenExpired(payload)) {
+  // Invalid signature, expired, or malformed token → redirect to login
+  if (!payload) {
     const loginUrl = new URL('/login', request.url);
     loginUrl.searchParams.set('redirect', pathname);
     const response = NextResponse.redirect(loginUrl);
-    // Clear the stale cookie
+    // Clear the stale/invalid cookie
     response.cookies.delete('access_token');
     return response;
   }

--- a/parkhub-web/package.json
+++ b/parkhub-web/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query-devtools": "^5.91.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "jose": "^6.2.2",
     "lucide-react": "^0.577.0",
     "next": "15.2.4",
     "next-themes": "^0.4.6",

--- a/parkhub-web/pnpm-lock.yaml
+++ b/parkhub-web/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   clsx:
     specifier: ^2.1.1
     version: 2.1.1
+  jose:
+    specifier: ^6.2.2
+    version: 6.2.2
   lucide-react:
     specifier: ^0.577.0
     version: 0.577.0(react@19.2.4)
@@ -971,7 +974,7 @@ packages:
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
       hono: 4.12.8
-      jose: 6.2.1
+      jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -3995,8 +3998,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jose@6.2.1:
-    resolution: {integrity: sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw==}
+  /jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
     dev: false
 
   /js-tokens@4.0.0:


### PR DESCRIPTION
## 背景

`middleware.ts` 仅做 base64 解码 JWT payload，未验证签名。攻击者可伪造任意 role（如 `platform_admin`）绕过前端路由权限。(#60)

## 变更点

| 文件 | 变更 |
|------|------|
| `parkhub-web/middleware.ts` | 用 `jose.jwtVerify` 替换 `atob` 解码，验证 HS256 签名 |
| `parkhub-web/package.json` | 新增 `jose@^6.2.2` 依赖 |
| `parkhub-web/pnpm-lock.yaml` | 锁文件更新 |

## 验收标准逐条对照

- [x] **JWT 签名经过验证，伪造 token 无法通过 middleware** — 使用 `jose.jwtVerify()` 进行 HS256 签名验证，伪造 token 抛出异常后返回 null，重定向到登录页
- [x] **签名验证失败时重定向到登录页** — `verifyJwtToken` 返回 null 时，middleware 重定向到 `/login` 并清除 cookie
- [x] **Token 缓存机制保留** — LRU 缓存保留，已验证 token 5 分钟内跳过签名验证
- [x] **Edge Runtime 兼容** — `jose` 纯 JavaScript 实现，不依赖 Node.js crypto 模块

## 验证

- `pnpm lint` — 无新增错误（既存 lint 警告与本次改动无关）
- `jose` 6.x 支持 Edge Runtime / Web Crypto API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #60